### PR TITLE
Bump python to 3.8

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         cache: 'pip'
     - run: pip install black==22.3.0
     - run: black --diff --check .

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -16,7 +16,7 @@ jobs:
           path: ""
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: 'pip'
       - run: |
           pip install pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
-target-version = ["py37"]
+target-version = ["py38"]
 exclude = 'files'


### PR DESCRIPTION
Since `i6_core` was upgraded to 3.8 I would suggest we do the same here. 
This will most likely crash the typing as stated in #10, but I think this is good because otherwise we get severe mismatches since most people I know don't locally use 3.7 anymore but rather either 3.8 or even 3.10.