### PR TITLE
Value check for config

### DIFF
--- a/i6_models/config.py
+++ b/i6_models/config.py
@@ -33,5 +33,12 @@ class ModelConfiguration:
             except typeguard.TypeCheckError as exc:
                 raise typeguard.TypeCheckError(f'In field "{field.name}" of "{type(self)}": {exc}')
 
+    def _value_check(self) -> None:
+        """
+        Base case for the function supposed to hold the value check of a config.
+        """
+        pass
+
     def __post_init__(self) -> None:
         self._validate_types()
+        self._value_check()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,8 +59,8 @@ def test_config_typing():
     with pytest.raises(TypeCheckError):
         TestConfiguration(num_layers=2.0, hidden_dim="One")
 
-def test_value_check():
 
+def test_value_check():
     @dataclass
     class TestConfiguration(ModelConfiguration):
         num_layers: int = 4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,3 +58,17 @@ def test_config_typing():
     TestConfiguration(num_layers=2, hidden_dim=1)
     with pytest.raises(TypeCheckError):
         TestConfiguration(num_layers=2.0, hidden_dim="One")
+
+def test_value_check():
+
+    @dataclass
+    class TestConfiguration(ModelConfiguration):
+        num_layers: int = 4
+        hidden_dim: int = 2
+
+        def _value_check(self) -> None:
+            assert self.num_layers % self.hidden_dim == 0, "Needs to be divisible"
+
+    TestConfiguration()
+    with pytest.raises(AssertionError):
+        TestConfiguration(num_layers=6, hidden_dim=5)


### PR DESCRIPTION
This adds the option to check some internal values of the config at the creation of the config. C.f. the test for some example. This could be useful if some parameters are to be in relation to each other. 