### PR TITLE
Add __all__ and __init__ files

### DIFF
--- a/i6_models/parts/conformer/__init__.py
+++ b/i6_models/parts/conformer/__init__.py
@@ -1,5 +1,4 @@
 from .convolution import *
 from .feedforward import *
-from .frontend import *
 from .mhsa import *
 from .norm import *

--- a/i6_models/parts/conformer/__init__.py
+++ b/i6_models/parts/conformer/__init__.py
@@ -1,0 +1,5 @@
+from .convolution import *
+from .feedforward import *
+from .frontend import *
+from .mhsa import *
+from .norm import *

--- a/i6_models/parts/conformer/convolution.py
+++ b/i6_models/parts/conformer/convolution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["ConformerConvolutionV1", "ConformerConvolutionV1Config"]
+
 from dataclasses import dataclass
 
 import torch

--- a/i6_models/parts/conformer/feedforward.py
+++ b/i6_models/parts/conformer/feedforward.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+__all__ = ["ConformerPositionwiseFeedForwardV1", "ConformerPositionwiseFeedForwardV1Config"]
+
 from dataclasses import dataclass
 from typing import Callable
 

--- a/i6_models/parts/conformer/mhsa.py
+++ b/i6_models/parts/conformer/mhsa.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
+__all__ = ["ConformerMHSAV1", "ConformerMHSAV1Config"]
 from dataclasses import dataclass
-from typing import Optional, Callable
+from typing import Optional
 import torch
 
 from i6_models.config import ModelConfiguration

--- a/i6_models/parts/conformer/norm.py
+++ b/i6_models/parts/conformer/norm.py
@@ -1,3 +1,4 @@
+__all__ = ["LayerNormNC"]
 import torch
 import torch.nn as nn
 


### PR DESCRIPTION
I think it is good to be able to import from e.g. `parts.conformer` and not have to think about the location of every single import.

I was even thinking to add something like `i6_models/model_imports/conformer.py` where all this file does is import all conformer init files from the 3 module types and have them bundled in one file. Opinions?