### PR TITLE
Explicit padding for ConformerConvolutionV1

### DIFF
--- a/i6_models/parts/conformer/convolution.py
+++ b/i6_models/parts/conformer/convolution.py
@@ -28,6 +28,9 @@ class ConformerConvolutionV1(nn.Module):
     """
     Conformer convolution module.
     see also: https://github.com/espnet/espnet/blob/713e784c0815ebba2053131307db5f00af5159ea/espnet/nets/pytorch_backend/conformer/convolution.py#L13
+
+    Uses explicit padding for ONNX exportability, see:
+    https://github.com/pytorch/pytorch/issues/68880
     """
 
     def __init__(self, model_cfg: ConformerConvolutionV1Config):
@@ -35,13 +38,13 @@ class ConformerConvolutionV1(nn.Module):
         :param model_cfg: model configuration for this module
         """
         super().__init__()
-
+        assert model_cfg.kernel_size % 2 == 1, "ConformerConvolutionV1 only supports odd kernel sizes"
         self.pointwise_conv1 = nn.Linear(in_features=model_cfg.channels, out_features=2 * model_cfg.channels)
         self.depthwise_conv = nn.Conv1d(
             in_channels=model_cfg.channels,
             out_channels=model_cfg.channels,
             kernel_size=model_cfg.kernel_size,
-            padding="same",
+            padding=(model_cfg.kernel_size - 1) // 2,
             groups=model_cfg.channels,
         )
         self.pointwise_conv2 = nn.Linear(in_features=model_cfg.channels, out_features=model_cfg.channels)

--- a/i6_models/parts/conformer/convolution.py
+++ b/i6_models/parts/conformer/convolution.py
@@ -23,6 +23,13 @@ class ConformerConvolutionV1Config(ModelConfiguration):
     norm: Union[nn.Module, Callable[[torch.Tensor], torch.Tensor]]
     """normalization layer with input of shape [N,C,T]"""
 
+    def check_valid(self):
+        assert self.kernel_size % 2 == 1, "ConformerConvolutionV1 only supports odd kernel sizes"
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.check_valid()
+
 
 class ConformerConvolutionV1(nn.Module):
     """
@@ -38,7 +45,7 @@ class ConformerConvolutionV1(nn.Module):
         :param model_cfg: model configuration for this module
         """
         super().__init__()
-        assert model_cfg.kernel_size % 2 == 1, "ConformerConvolutionV1 only supports odd kernel sizes"
+        model_cfg.check_valid()
         self.pointwise_conv1 = nn.Linear(in_features=model_cfg.channels, out_features=2 * model_cfg.channels)
         self.depthwise_conv = nn.Conv1d(
             in_channels=model_cfg.channels,

--- a/tests/test_conformer.py
+++ b/tests/test_conformer.py
@@ -32,7 +32,6 @@ def test_conformer_convolution_output_shape():
     assert get_output_shape(10, 1, 50) == (10, 1, 50)  # time dim 1
     assert get_output_shape(10, 10, 20, dropout=0.0) == (10, 10, 20)  # dropout 0
     assert get_output_shape(10, 10, 20, kernel_size=3) == (10, 10, 20)  # odd kernel size
-    assert get_output_shape(10, 10, 20, kernel_size=32) == (10, 10, 20)  # even kernel size
 
 
 def test_ConformerPositionwiseFeedForwardV1():


### PR DESCRIPTION
In case we want to use the model in pipelines for ONNX export, we can not use `padding="same"` for now:
https://github.com/pytorch/pytorch/issues/68880

While workarounds would be possible, I would strongly advise to not introduce export hacks already for our first model. Also while export might work, it is unclear if the ONNX runtime does.