### PR TITLE
Fix MHSA masking

### DIFF
--- a/i6_models/parts/conformer/mhsa.py
+++ b/i6_models/parts/conformer/mhsa.py
@@ -39,17 +39,17 @@ class ConformerMHSAV1(torch.nn.Module):
         )
         self.dropout = cfg.dropout
 
-    def forward(self, input_tensor: torch.Tensor, key_padding_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(self, input_tensor: torch.Tensor, sequence_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
         """
         Apply layer norm and multi-head self attention and dropout
-        :param Optional[torch.Tensor] key_padding_mask: could be a binary or float mask of shape (B, T)
+        :param Optional[torch.Tensor] sequence_mask: could be a binary or float mask of shape (B, T), 1 signals within sequence, 0 outside, will be inverted to match the torch.nn.MultiheadAttention module
         which will be applied/added to dot product, used to mask padded key positions out
         """
-
+        inv_sequence_mask = 1 - sequence_mask
         output_tensor = self.layernorm(input_tensor)  # [B,T,F]
 
         output_tensor, _ = self.mhsa(
-            output_tensor, output_tensor, output_tensor, key_padding_mask=key_padding_mask, need_weights=False
+            output_tensor, output_tensor, output_tensor, key_padding_mask=inv_sequence_mask, need_weights=False
         )  # [B,T,F]
         output_tensor = torch.nn.functional.dropout(output_tensor, p=self.dropout, training=self.training)  # [B,T,F]
 

--- a/i6_models/parts/conformer/mhsa.py
+++ b/i6_models/parts/conformer/mhsa.py
@@ -45,7 +45,7 @@ class ConformerMHSAV1(torch.nn.Module):
         :param Optional[torch.Tensor] sequence_mask: could be a binary or float mask of shape (B, T), 1 signals within sequence, 0 outside, will be inverted to match the torch.nn.MultiheadAttention module
         which will be applied/added to dot product, used to mask padded key positions out
         """
-        inv_sequence_mask = 1 - sequence_mask
+        inv_sequence_mask = (1 - sequence_mask).bool()
         output_tensor = self.layernorm(input_tensor)  # [B,T,F]
 
         output_tensor, _ = self.mhsa(


### PR DESCRIPTION
This PR fixes the masking issue talked about today (that we usually want 1 to mark positions which are in the sequence, but MHSA expects the other way around)
Also the docstring indicates to me that for float mask weird things happen, so I added a bool conversion. 
```
        key_padding_mask: If specified, a mask of shape :math:`(N, S)` indicating which elements within ``key``
            to ignore for the purpose of attention (i.e. treat as "padding"). For unbatched `query`, shape should be :math:`(S)`.
            Binary and float masks are supported.
            For a binary mask, a ``True`` value indicates that the corresponding ``key`` value will be ignored for
            the purpose of attention. For a float mask, it will be directly added to the corresponding ``key`` value.
```
