### PR TITLE
Frontends: Add tensor info to assert

### DIFF
--- a/i6_models/parts/frontend/generic_frontend.py
+++ b/i6_models/parts/frontend/generic_frontend.py
@@ -195,7 +195,7 @@ class GenericFrontendV1(nn.Module):
             )
 
     def forward(self, tensor: torch.Tensor, sequence_mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert tensor.shape[-1] == self.cfg.in_features
+        assert tensor.shape[-1] == self.cfg.in_features, f"{tensor.shape[-1]} vs {self.cfg.in_features}"
         # and add a dim
         tensor = tensor[:, None, :, :]  # [B,C=1,T,F]
 

--- a/i6_models/parts/frontend/generic_frontend.py
+++ b/i6_models/parts/frontend/generic_frontend.py
@@ -195,7 +195,7 @@ class GenericFrontendV1(nn.Module):
             )
 
     def forward(self, tensor: torch.Tensor, sequence_mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert tensor.shape[-1] == self.cfg.in_features, f"{tensor.shape[-1]} vs {self.cfg.in_features}"
+        assert tensor.shape[-1] == self.cfg.in_features, f"shape {tensor.shape} vs in features {self.cfg.in_features}"
         # and add a dim
         tensor = tensor[:, None, :, :]  # [B,C=1,T,F]
 

--- a/i6_models/parts/frontend/vgg_act.py
+++ b/i6_models/parts/frontend/vgg_act.py
@@ -158,7 +158,7 @@ class VGG4LayerActFrontendV1(nn.Module):
         :param sequence_mask: the sequence mask for the tensor
         :return: torch.Tensor of shape [B,T",F'] and the shape of the sequence mask
         """
-        assert tensor.shape[-1] == self.cfg.in_features, f"{tensor.shape[-1]} vs {self.cfg.in_features}"
+        assert tensor.shape[-1] == self.cfg.in_features, f"shape {tensor.shape} vs in features {self.cfg.in_features}"
         # and add a dim
         tensor = tensor[:, None, :, :]  # [B,C=1,T,F]
 

--- a/i6_models/parts/frontend/vgg_act.py
+++ b/i6_models/parts/frontend/vgg_act.py
@@ -158,7 +158,7 @@ class VGG4LayerActFrontendV1(nn.Module):
         :param sequence_mask: the sequence mask for the tensor
         :return: torch.Tensor of shape [B,T",F'] and the shape of the sequence mask
         """
-        assert tensor.shape[-1] == self.cfg.in_features
+        assert tensor.shape[-1] == self.cfg.in_features, f"{tensor.shape[-1]} vs {self.cfg.in_features}"
         # and add a dim
         tensor = tensor[:, None, :, :]  # [B,C=1,T,F]
 


### PR DESCRIPTION
I think it makes sense to print the failed shapes already with the assert, so the user can directly see the mismatch themselves.