### PR TITLE
Add diphone factored hybrid model output block

### DIFF
--- a/i6_models/parts/factored_hybrid/__init__.py
+++ b/i6_models/parts/factored_hybrid/__init__.py
@@ -1,0 +1,10 @@
+__all__ = [
+    "DiphoneLogitsV1",
+    "DiphoneProbsV1",
+    "DiphoneBackendV1Config",
+    "DiphoneBackendV1",
+    "PhonemeStateClassV1",
+]
+
+from .diphone import *
+from .util import PhonemeStateClassV1

--- a/i6_models/parts/factored_hybrid/__init__.py
+++ b/i6_models/parts/factored_hybrid/__init__.py
@@ -1,10 +1,4 @@
-__all__ = [
-    "DiphoneLogitsV1",
-    "DiphoneProbsV1",
-    "DiphoneBackendV1Config",
-    "DiphoneBackendV1",
-    "PhonemeStateClassV1",
-]
+__all__ = ["FactoredDiphoneBlockV1Config", "FactoredDiphoneBlockV1", "BoundaryClassV1"]
 
 from .diphone import *
-from .util import PhonemeStateClassV1
+from .util import BoundaryClassV1

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -51,11 +51,11 @@ class FactoredDiphoneBlockV1Config(ModelConfiguration):
 
         assert self.num_contexts > 0
         assert self.num_hmm_states_per_phone > 0
-        
+
         assert self.context_mix_mlp_dim > 0
         assert self.context_mix_mlp_num_layers > 0
         assert self.left_context_embedding_dim > 0
-        
+
         assert self.num_inputs > 0
         assert 0.0 <= self.dropout <= 1.0, "dropout must be a probability"
 

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -1,12 +1,10 @@
 __all__ = [
-    "DiphoneLogitsV1",
-    "DiphoneProbsV1",
-    "DiphoneBackendV1Config",
-    "DiphoneBackendV1",
+    "FactoredDiphoneBlockV1Config",
+    "FactoredDiphoneBlockV1",
 ]
 
 from dataclasses import dataclass
-from typing import Callable, Optional, Union
+from typing import Callable, Tuple, Union
 
 import torch
 from torch import nn, Tensor
@@ -14,29 +12,11 @@ import torch.nn.functional as F
 
 from i6_models.config import ModelConfiguration
 
-from .util import PhonemeStateClassV1, get_center_dim, get_mlp
+from .util import BoundaryClassV1, get_center_dim, get_mlp
 
 
 @dataclass
-class DiphoneLogitsV1:
-    """outputs of a diphone factored hybrid model"""
-
-    embeddings_left_context: Tensor
-    """the embedded left context values"""
-
-    output_center: Tensor
-    """center output"""
-
-    output_left: Tensor
-    """left output"""
-
-
-class DiphoneProbsV1(DiphoneLogitsV1):
-    """marker class indicating that the output tensors store probabilities and not logits"""
-
-
-@dataclass
-class DiphoneBackendV1Config(ModelConfiguration):
+class FactoredDiphoneBlockV1Config(ModelConfiguration):
     """
     Attributes:
         context_mix_mlp_dim: inner dimension of the context mixing MLP layers
@@ -46,7 +26,7 @@ class DiphoneBackendV1Config(ModelConfiguration):
             values. Good choice is in the order of n_contexts.
         n_contexts: the number of raw phonemes/acoustic contexts
         num_hmm_states_per_phone: the number of HMM states per phoneme
-        num_inputs: input dimension of the backend, must match w/ output dimension
+        num_inputs: input dimension of the output block, must match w/ output dimension
             of main encoder (e.g. Conformer)
         phoneme_state_class: the phoneme state augmentation to apply
         activation: activation function to use in the context mixing MLP.
@@ -55,7 +35,7 @@ class DiphoneBackendV1Config(ModelConfiguration):
     left_context_embedding_dim: int
     n_contexts: int
     num_hmm_states_per_phone: int
-    phoneme_state_class: Union[int, PhonemeStateClassV1]
+    boundary_class: Union[int, BoundaryClassV1]
 
     activation: Callable[[], nn.Module]
     context_mix_mlp_dim: int
@@ -75,15 +55,15 @@ class DiphoneBackendV1Config(ModelConfiguration):
         assert 0.0 <= self.dropout <= 1.0, "dropout must be a probability"
 
 
-class DiphoneBackendV1(nn.Module):
+class FactoredDiphoneBlockV1(nn.Module):
     """
-    Diphone FH model backend.
+    Diphone FH model output block.
 
-    Consumes the output h(x) of a main encoder model and computes factored output
-    logits/probabilities for p(c|l,x) and p(l|x).
+    Consumes the output h(x) of a main encoder model and computes factored or joint
+    output logits/probabilities for p(c|l,x) and p(l|x).
     """
 
-    def __init__(self, cfg: DiphoneBackendV1Config):
+    def __init__(self, cfg: FactoredDiphoneBlockV1Config):
         super().__init__()
 
         self.n_contexts = cfg.n_contexts
@@ -99,7 +79,7 @@ class DiphoneBackendV1(nn.Module):
         self.left_context_embedding = nn.Embedding(cfg.n_contexts, cfg.left_context_embedding_dim)
         self.center_encoder = get_mlp(
             num_input=cfg.num_inputs + cfg.left_context_embedding_dim,
-            num_output=get_center_dim(cfg.n_contexts, cfg.num_hmm_states_per_phone, cfg.phoneme_state_class),
+            num_output=get_center_dim(cfg.n_contexts, cfg.num_hmm_states_per_phone, cfg.boundary_class),
             hidden_dim=cfg.context_mix_mlp_dim,
             num_layers=cfg.context_mix_mlp_num_layers,
             dropout=cfg.dropout,
@@ -109,59 +89,46 @@ class DiphoneBackendV1(nn.Module):
     def forward(
         self,
         features: Tensor,  # B, T, F
-        contexts_left: Optional[Tensor] = None,  # B, T
-    ) -> Union[DiphoneLogitsV1, DiphoneProbsV1]:
+        contexts_left: Tensor,  # B, T
+    ) -> Tuple[Tensor, Tensor, Tensor]:
         """
         :param features: Main encoder output. shape B, T, F. F=num_inputs
-        :param contexts_left: The left contexts used to compute p(c|l,x).
-            Shape during training: B, T. Must be `None` when forwarding as the model
-            will compute a flat, joint output scoring all possible contexts in forwarding
-            mode.
-        :return: During training: logits for p(c|l,x) and p(l|x).
-            During inference: *log* probs for p(c,l|x) in one large layer.
+        :param contexts_left: The left contexts used to compute p(c|l,x), shape B, T.
+        :return: tuple of logits for p(c|l,x), p(l|x) and the embedded left context values.
+        """
+
+        left_logits = self.left_context_encoder(features)  # B, T, C
+        # in training we forward exactly one context per T, so: B, T, E
+        contexts_embedded_left = self.left_context_embedding(contexts_left)
+        features_center = torch.cat((features, contexts_embedded_left), -1)  # B, T, F+E
+        logits_center = self.center_encoder(features_center)  # B, T, C
+
+        return logits_center, left_logits, contexts_embedded_left
+
+    def forward_joint(self, features: Tensor) -> Tensor:
+        """
+        :param features: Main encoder output. shape B, T, F. F=num_inputs
+        :return: log probabilities for p(c,l|x).
         """
 
         left_logits = self.left_context_encoder(features)  # B, T, C
 
-        if self.training:
-            assert contexts_left is not None
-            assert contexts_left.ndim >= 2
-        else:
-            assert contexts_left is None, "in eval mode, all left contexts are forwarded at the same time"
-            contexts_left = torch.arange(self.n_contexts)
+        # here we forward every context to compute p(c, l|x) = p(c|l, x) * p(l|x)
+        contexts_left = torch.arange(self.n_contexts)
+        contexts_embedded_left = self.left_context_embedding(contexts_left)
 
-        # train: B, T, E
-        # eval: C, E
-        embedded_left_contexts = self.left_context_embedding(contexts_left)
+        features = features.expand((self.n_contexts, -1, -1, -1))  # C, B, T, F
+        contexts_embedded_left_ = contexts_embedded_left.reshape((self.n_contexts, 1, 1, -1)).expand(
+            (-1, *features.shape[1:3], -1)
+        )  # C, B, T, E
+        features_center = torch.cat((features, contexts_embedded_left_), -1)  # C, B, T, F+E
+        logits_center = self.center_encoder(features_center)  # C, B, T, F'
+        log_probs_center = F.log_softmax(logits_center, -1)
+        log_probs_center = log_probs_center.permute((1, 2, 3, 0))  # B, T, F', C
+        log_probs_left = F.log_softmax(left_logits, -1)
+        log_probs_left = log_probs_left.unsqueeze(-2)  # B, T, 1, C
 
-        if self.training:
-            # in training we forward exactly one context per T
+        joint_log_probs = log_probs_center + log_probs_left  # B, T, F', C
+        joint_log_probs = torch.flatten(joint_log_probs, start_dim=2)  # B, T, joint
 
-            center_features = torch.cat((features, embedded_left_contexts), -1)  # B, T, F+E
-            center_logits = self.center_encoder(center_features)  # B, T, C
-
-            return DiphoneLogitsV1(
-                embeddings_left_context=embedded_left_contexts, output_left=left_logits, output_center=center_logits
-            )
-        else:
-            # here we forward every context to compute p(c, l|x) = p(c|l, x) * p(l|x)
-
-            features = features.expand((self.n_contexts, -1, -1, -1))  # C, B, T, F
-            embedded_left_contexts_ = embedded_left_contexts.reshape((self.n_contexts, 1, 1, -1)).expand(
-                (-1, *features.shape[1:3], -1)
-            )  # C, B, T, E
-            center_features = torch.cat((features, embedded_left_contexts_), -1)  # C, B, T, F+E
-            center_logits = self.center_encoder(center_features)  # C, B, T, F'
-            center_probs = F.log_softmax(center_logits, -1)
-            center_probs = center_probs.permute((1, 2, 3, 0))  # B, T, F', C
-            left_probs = F.log_softmax(left_logits, -1)
-            left_probs = left_probs.unsqueeze(-2)  # B, T, 1, C
-
-            joint_probs = center_probs + left_probs  # B, T, F', C
-            joint_probs = torch.flatten(joint_probs, start_dim=2)  # B, T, joint
-
-            return DiphoneProbsV1(
-                embeddings_left_context=embedded_left_contexts,
-                output_left=left_probs.squeeze(),
-                output_center=joint_probs,
-            )
+        return joint_log_probs

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -86,7 +86,10 @@ class FactoredDiphoneBlockV1(nn.Module):
             activation=cfg.activation,
         )
 
-    def forward(
+    def forward(self, *args, **kwargs) -> Tuple[Tensor, Tensor, Tensor]:
+        return self.forward_factored(*args, **kwargs)
+
+    def forward_factored(
         self,
         features: Tensor,  # B, T, F
         contexts_left: Tensor,  # B, T

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -1,0 +1,167 @@
+__all__ = [
+    "DiphoneLogitsV1",
+    "DiphoneProbsV1",
+    "DiphoneBackendV1Config",
+    "DiphoneBackendV1",
+]
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Union
+
+import torch
+from torch import nn, Tensor
+import torch.nn.functional as F
+
+from i6_models.config import ModelConfiguration
+
+from .util import PhonemeStateClassV1, get_center_dim, get_mlp
+
+
+@dataclass
+class DiphoneLogitsV1:
+    """outputs of a diphone factored hybrid model"""
+
+    embeddings_left_context: Tensor
+    """the embedded left context values"""
+
+    output_center: Tensor
+    """center output"""
+
+    output_left: Tensor
+    """left output"""
+
+
+class DiphoneProbsV1(DiphoneLogitsV1):
+    """marker class indicating that the output tensors store probabilities and not logits"""
+
+
+@dataclass
+class DiphoneBackendV1Config(ModelConfiguration):
+    """
+    Attributes:
+        context_mix_mlp_dim: inner dimension of the context mixing MLP layers
+        context_mix_mlp_num_layers: how many hidden layers on the MLPs there should be
+        dropout: dropout probabilty
+        left_context_embedding_dim: embedding dimension of the left context
+            values. Good choice is in the order of n_contexts.
+        n_contexts: the number of raw phonemes/acoustic contexts
+        num_hmm_states_per_phone: the number of HMM states per phoneme
+        num_inputs: input dimension of the backend, must match w/ output dimension
+            of main encoder (e.g. Conformer)
+        phoneme_state_class: the phoneme state augmentation to apply
+        activation: activation function to use in the context mixing MLP.
+    """
+
+    left_context_embedding_dim: int
+    n_contexts: int
+    num_hmm_states_per_phone: int
+    phoneme_state_class: Union[int, PhonemeStateClassV1]
+
+    activation: Callable[[], nn.Module]
+    context_mix_mlp_dim: int
+    context_mix_mlp_num_layers: int
+    dropout: float
+    num_inputs: int
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        assert self.context_mix_mlp_dim > 0
+        assert self.context_mix_mlp_num_layers > 0
+        assert self.n_contexts > 0
+        assert self.num_hmm_states_per_phone > 0
+        assert self.num_inputs > 0
+        assert self.left_context_embedding_dim > 0
+        assert 0.0 <= self.dropout <= 1.0, "dropout must be a probability"
+
+
+class DiphoneBackendV1(nn.Module):
+    """
+    Diphone FH model backend.
+
+    Consumes the output h(x) of a main encoder model and computes factored output
+    logits/probabilities for p(c|l,x) and p(l|x).
+    """
+
+    def __init__(self, cfg: DiphoneBackendV1Config):
+        super().__init__()
+
+        self.n_contexts = cfg.n_contexts
+
+        self.left_context_encoder = get_mlp(
+            num_input=cfg.num_inputs,
+            num_output=cfg.n_contexts,
+            hidden_dim=cfg.context_mix_mlp_dim,
+            num_layers=cfg.context_mix_mlp_num_layers,
+            dropout=cfg.dropout,
+            activation=cfg.activation,
+        )
+        self.left_context_embedding = nn.Embedding(cfg.n_contexts, cfg.left_context_embedding_dim)
+        self.center_encoder = get_mlp(
+            num_input=cfg.num_inputs + cfg.left_context_embedding_dim,
+            num_output=get_center_dim(cfg.n_contexts, cfg.num_hmm_states_per_phone, cfg.phoneme_state_class),
+            hidden_dim=cfg.context_mix_mlp_dim,
+            num_layers=cfg.context_mix_mlp_num_layers,
+            dropout=cfg.dropout,
+            activation=cfg.activation,
+        )
+
+    def forward(
+        self,
+        features: Tensor,  # B, T, F
+        contexts_left: Optional[Tensor] = None,  # B, T
+    ) -> Union[DiphoneLogitsV1, DiphoneProbsV1]:
+        """
+        :param features: Main encoder output. shape B, T, F. F=num_inputs
+        :param contexts_left: The left contexts used to compute p(c|l,x).
+            Shape during training: B, T. Must be `None` when forwarding as the model
+            will compute a flat, joint output scoring all possible contexts in forwarding
+            mode.
+        :return: During training: logits for p(c|l,x) and p(l|x).
+            During inference: *log* probs for p(c,l|x) in one large layer.
+        """
+
+        left_logits = self.left_context_encoder(features)  # B, T, C
+
+        if self.training:
+            assert contexts_left is not None
+            assert contexts_left.ndim >= 2
+        else:
+            assert contexts_left is None, "in eval mode, all left contexts are forwarded at the same time"
+            contexts_left = torch.arange(self.n_contexts)
+
+        # train: B, T, E
+        # eval: C, E
+        embedded_left_contexts = self.left_context_embedding(contexts_left)
+
+        if self.training:
+            # in training we forward exactly one context per T
+
+            center_features = torch.cat((features, embedded_left_contexts), -1)  # B, T, F+E
+            center_logits = self.center_encoder(center_features)  # B, T, C
+
+            return DiphoneLogitsV1(
+                embeddings_left_context=embedded_left_contexts, output_left=left_logits, output_center=center_logits
+            )
+        else:
+            # here we forward every context to compute p(c, l|x) = p(c|l, x) * p(l|x)
+
+            features = features.expand((self.n_contexts, -1, -1, -1))  # C, B, T, F
+            embedded_left_contexts_ = embedded_left_contexts.reshape((self.n_contexts, 1, 1, -1)).expand(
+                (-1, *features.shape[1:3], -1)
+            )  # C, B, T, E
+            center_features = torch.cat((features, embedded_left_contexts_), -1)  # C, B, T, F+E
+            center_logits = self.center_encoder(center_features)  # C, B, T, F'
+            center_probs = F.log_softmax(center_logits, -1)
+            center_probs = center_probs.permute((1, 2, 3, 0))  # B, T, F', C
+            left_probs = F.log_softmax(left_logits, -1)
+            left_probs = left_probs.unsqueeze(-2)  # B, T, 1, C
+
+            joint_probs = center_probs + left_probs  # B, T, F', C
+            joint_probs = torch.flatten(joint_probs, start_dim=2)  # B, T, joint
+
+            return DiphoneProbsV1(
+                embeddings_left_context=embedded_left_contexts,
+                output_left=left_probs.squeeze(),
+                output_center=joint_probs,
+            )

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -140,4 +140,9 @@ class FactoredDiphoneBlockV1(nn.Module):
         joint_log_probs = log_probs_center + log_probs_left  # B, T, F', C
         joint_log_probs = torch.flatten(joint_log_probs, start_dim=2)  # B, T, F'*C
 
+        # assert shape for ONNX converter
+        joint_log_probs = joint_log_probs.reshape(
+            (features.shape[0], features.shape[1], self.num_diphone)
+        )  # B, T, F'*C
+
         return joint_log_probs

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -118,7 +118,7 @@ class FactoredDiphoneBlockV1(nn.Module):
         left_logits = self.left_context_encoder(features)  # B, T, C
 
         # here we forward every context to compute p(c, l|x) = p(c|l, x) * p(l|x)
-        contexts_left = torch.arange(self.n_contexts).to(device=features.device)  # C
+        contexts_left = torch.arange(self.n_contexts, device=features.device)  # C
         contexts_embedded_left = self.left_context_embedding(contexts_left)  # C, E
 
         features = features.expand((self.n_contexts, -1, -1, -1))  # C, B, T, F

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -138,9 +138,6 @@ class FactoredDiphoneBlockV1(nn.Module):
         log_probs_left = log_probs_left.unsqueeze(-2)  # B, T, 1, C
 
         joint_log_probs = log_probs_center + log_probs_left  # B, T, F', C
-        joint_log_probs = torch.flatten(joint_log_probs, start_dim=2)  # B, T, F'*C
-
-        # assert shape for ONNX converter
         joint_log_probs = joint_log_probs.reshape(
             (features.shape[0], features.shape[1], self.num_diphone)
         )  # B, T, F'*C

--- a/i6_models/parts/factored_hybrid/diphone.py
+++ b/i6_models/parts/factored_hybrid/diphone.py
@@ -93,7 +93,7 @@ class FactoredDiphoneBlockV1(nn.Module):
         self,
         features: Tensor,  # B, T, F
         contexts_left: Tensor,  # B, T
-        **kwargs,
+        **kwargs,  # kwargs because the train_step function passes contexts_center for right context training
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
         :param features: Main encoder output. shape B, T, F. F=num_inputs

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -66,8 +66,8 @@ def get_mlp(
             ]
             for layer in [
                 nn.Linear(in_dim, hidden_dim),
-                nn.Dropout(dropout),
                 activation(),
+                nn.Dropout(dropout),
             ]
         ],
         nn.Linear(hidden_dim, num_output, bias=True),

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -70,5 +70,5 @@ def get_mlp(
                 nn.Dropout(dropout),
             ]
         ],
-        nn.Linear(hidden_dim, num_output, bias=True),
+        nn.Linear(hidden_dim, num_output),
     )

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -14,7 +14,7 @@ class BoundaryClassV1(Enum):
     def factor(self):
         return self.value
 
-    @staticmethod
+    @classmethod
     def from_flags(cls, use_word_end_classes: bool, use_boundary_classes: bool) -> "BoundaryClassV1":
         assert not (use_word_end_classes and use_boundary_classes), "cannot use both classes"
 

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -25,6 +25,13 @@ class BoundaryClassV1(Enum):
         else:
             return cls.none
 
+    @classmethod
+    def from_dense_label_info(cls, li: "i6_core.mm.context_label.DenseLabelInfo") -> "BoundaryClassV1":
+        return cls.from_flags(
+            use_word_end_classes=li.use_word_end_classes,
+            use_boundary_classes=li.use_boundary_classes,
+        )
+
 
 def get_center_dim(
     n_contexts: int,

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -4,7 +4,7 @@ from typing import Callable, Union
 from torch import nn
 
 
-class PhonemeStateClassV1(Enum):
+class BoundaryClassV1(Enum):
     """Phoneme state class augmentation selector"""
 
     none = 1
@@ -15,7 +15,7 @@ class PhonemeStateClassV1(Enum):
         return self.value
 
     @staticmethod
-    def from_flags(cls, use_word_end_classes: bool, use_boundary_classes: bool) -> "PhonemeStateClassV1":
+    def from_flags(cls, use_word_end_classes: bool, use_boundary_classes: bool) -> "BoundaryClassV1":
         assert not (use_word_end_classes and use_boundary_classes), "cannot use both classes"
 
         if use_boundary_classes:
@@ -29,13 +29,13 @@ class PhonemeStateClassV1(Enum):
 def get_center_dim(
     n_contexts: int,
     num_hmm_states_per_phone: int,
-    ph_class: Union[int, PhonemeStateClassV1],
+    ph_class: Union[int, BoundaryClassV1],
 ) -> int:
     """
     :return: number of center phonemes given the augmentation values
     """
 
-    factor = ph_class.factor() if isinstance(ph_class, PhonemeStateClassV1) else ph_class
+    factor = ph_class.factor() if isinstance(ph_class, BoundaryClassV1) else ph_class
     return n_contexts * num_hmm_states_per_phone * factor
 
 

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -1,0 +1,63 @@
+from enum import Enum
+from typing import Callable, Union
+
+from torch import nn
+
+
+class PhonemeStateClassV1(Enum):
+    """Phoneme state class augmentation selector"""
+
+    none = 1
+    word_end = 2
+    boundary = 4
+
+    def factor(self):
+        return self.value
+
+
+def get_center_dim(
+    n_contexts: int,
+    num_hmm_states_per_phone: int,
+    ph_class: Union[int, PhonemeStateClassV1],
+) -> int:
+    """
+    :return: number of center phonemes given the augmentation values
+    """
+
+    factor = ph_class.factor() if isinstance(ph_class, PhonemeStateClassV1) else ph_class
+    return n_contexts * num_hmm_states_per_phone * factor
+
+
+def get_mlp(
+    num_input: int,
+    num_output: int,
+    hidden_dim: int,
+    dropout: float,
+    activation: Callable[[], nn.Module],
+    num_layers,
+) -> nn.Module:
+    """
+    :return: a context-mixing MLP according to the specifications
+    """
+
+    assert num_input > 0
+    assert num_output > 0
+    assert num_layers > 0
+    assert hidden_dim > 0
+    assert 0.0 <= dropout <= 1.0
+
+    return nn.Sequential(
+        *[
+            layer
+            for in_dim in [
+                num_input,
+                *[hidden_dim for _ in range(num_layers - 1)],
+            ]
+            for layer in [
+                nn.Linear(in_dim, hidden_dim),
+                nn.Dropout(dropout),
+                activation(),
+            ]
+        ],
+        nn.Linear(hidden_dim, num_output, bias=True),
+    )

--- a/i6_models/parts/factored_hybrid/util.py
+++ b/i6_models/parts/factored_hybrid/util.py
@@ -14,6 +14,17 @@ class PhonemeStateClassV1(Enum):
     def factor(self):
         return self.value
 
+    @staticmethod
+    def from_flags(cls, use_word_end_classes: bool, use_boundary_classes: bool) -> "PhonemeStateClassV1":
+        assert not (use_word_end_classes and use_boundary_classes), "cannot use both classes"
+
+        if use_boundary_classes:
+            return cls.boundary
+        elif use_word_end_classes:
+            return cls.word_end
+        else:
+            return cls.none
+
 
 def get_center_dim(
     n_contexts: int,

--- a/tests/test_fh.py
+++ b/tests/test_fh.py
@@ -16,7 +16,7 @@ def test_dim_calcs():
     assert get_center_dim(n_ctx, 3, BoundaryClassV1.boundary) == 504
 
 
-def test_output_shape():
+def test_output_shape_and_norm():
     n_ctx = 42
     n_in = 32
 

--- a/tests/test_fh.py
+++ b/tests/test_fh.py
@@ -1,0 +1,68 @@
+from itertools import product
+
+import torch
+import torch.nn as nn
+
+from i6_models.parts.factored_hybrid import (
+    DiphoneBackendV1,
+    DiphoneBackendV1Config,
+    PhonemeStateClassV1,
+    DiphoneLogitsV1,
+    DiphoneProbsV1,
+)
+from i6_models.parts.factored_hybrid.util import get_center_dim
+
+
+def test_dim_calcs():
+    n_ctx = 42
+
+    assert get_center_dim(n_ctx, 1, PhonemeStateClassV1.none) == 42
+    assert get_center_dim(n_ctx, 1, PhonemeStateClassV1.word_end) == 84
+    assert get_center_dim(n_ctx, 3, PhonemeStateClassV1.word_end) == 252
+    assert get_center_dim(n_ctx, 3, PhonemeStateClassV1.boundary) == 504
+
+
+def test_output_shape():
+    n_ctx = 42
+    n_in = 32
+
+    for we_class, states_per_ph in product(
+        [PhonemeStateClassV1.none, PhonemeStateClassV1.word_end, PhonemeStateClassV1.boundary],
+        [1, 3],
+    ):
+        backend = DiphoneBackendV1(
+            DiphoneBackendV1Config(
+                activation=lambda: nn.ReLU(),
+                context_mix_mlp_dim=64,
+                context_mix_mlp_num_layers=2,
+                dropout=0.1,
+                left_context_embedding_dim=32,
+                n_contexts=n_ctx,
+                num_hmm_states_per_phone=states_per_ph,
+                num_inputs=n_in,
+                phoneme_state_class=we_class,
+            )
+        )
+
+        backend.train(True)
+        for b, t in product([10, 50, 100], [10, 50, 100]):
+            contexts_forward = torch.randint(0, n_ctx, (b, t))
+            encoder_output = torch.rand((b, t, n_in))
+            output = backend(features=encoder_output, contexts_left=contexts_forward)
+            assert isinstance(output, DiphoneLogitsV1) and not isinstance(output, DiphoneProbsV1)
+            assert output.output_left.shape == (b, t, n_ctx)
+            cdim = get_center_dim(n_ctx, states_per_ph, we_class)
+            assert output.output_center.shape == (b, t, cdim)
+
+        backend.train(False)
+        for b, t in product([10, 50, 100], [10, 50, 100]):
+            encoder_output = torch.rand((b, t, n_in))
+            output = backend(features=encoder_output)
+            assert isinstance(output, DiphoneProbsV1)
+            assert output.output_left.shape == (b, t, n_ctx)
+            cdim = get_center_dim(n_ctx, states_per_ph, we_class)
+            assert output.output_center.shape == (b, t, cdim * n_ctx)
+            output_p = torch.exp(output.output_center)
+            ones_hopefully = torch.sum(output_p, dim=-1)
+            close_to_one = torch.abs(1 - ones_hopefully).flatten() < 1e-3
+            assert all(close_to_one)

--- a/tests/test_fh.py
+++ b/tests/test_fh.py
@@ -31,7 +31,7 @@ def test_output_shape():
                 context_mix_mlp_num_layers=2,
                 dropout=0.1,
                 left_context_embedding_dim=32,
-                n_contexts=n_ctx,
+                num_contexts=n_ctx,
                 num_hmm_states_per_phone=states_per_ph,
                 num_inputs=n_in,
                 boundary_class=we_class,

--- a/tests/test_fh.py
+++ b/tests/test_fh.py
@@ -3,23 +3,17 @@ from itertools import product
 import torch
 import torch.nn as nn
 
-from i6_models.parts.factored_hybrid import (
-    DiphoneBackendV1,
-    DiphoneBackendV1Config,
-    PhonemeStateClassV1,
-    DiphoneLogitsV1,
-    DiphoneProbsV1,
-)
+from i6_models.parts.factored_hybrid import BoundaryClassV1, FactoredDiphoneBlockV1, FactoredDiphoneBlockV1Config
 from i6_models.parts.factored_hybrid.util import get_center_dim
 
 
 def test_dim_calcs():
     n_ctx = 42
 
-    assert get_center_dim(n_ctx, 1, PhonemeStateClassV1.none) == 42
-    assert get_center_dim(n_ctx, 1, PhonemeStateClassV1.word_end) == 84
-    assert get_center_dim(n_ctx, 3, PhonemeStateClassV1.word_end) == 252
-    assert get_center_dim(n_ctx, 3, PhonemeStateClassV1.boundary) == 504
+    assert get_center_dim(n_ctx, 1, BoundaryClassV1.none) == 42
+    assert get_center_dim(n_ctx, 1, BoundaryClassV1.word_end) == 84
+    assert get_center_dim(n_ctx, 3, BoundaryClassV1.word_end) == 252
+    assert get_center_dim(n_ctx, 3, BoundaryClassV1.boundary) == 504
 
 
 def test_output_shape():
@@ -27,12 +21,12 @@ def test_output_shape():
     n_in = 32
 
     for we_class, states_per_ph in product(
-        [PhonemeStateClassV1.none, PhonemeStateClassV1.word_end, PhonemeStateClassV1.boundary],
+        [BoundaryClassV1.none, BoundaryClassV1.word_end, BoundaryClassV1.boundary],
         [1, 3],
     ):
-        backend = DiphoneBackendV1(
-            DiphoneBackendV1Config(
-                activation=lambda: nn.ReLU(),
+        block = FactoredDiphoneBlockV1(
+            FactoredDiphoneBlockV1Config(
+                activation=nn.ReLU,
                 context_mix_mlp_dim=64,
                 context_mix_mlp_num_layers=2,
                 dropout=0.1,
@@ -40,29 +34,23 @@ def test_output_shape():
                 n_contexts=n_ctx,
                 num_hmm_states_per_phone=states_per_ph,
                 num_inputs=n_in,
-                phoneme_state_class=we_class,
+                boundary_class=we_class,
             )
         )
 
-        backend.train(True)
         for b, t in product([10, 50, 100], [10, 50, 100]):
             contexts_forward = torch.randint(0, n_ctx, (b, t))
             encoder_output = torch.rand((b, t, n_in))
-            output = backend(features=encoder_output, contexts_left=contexts_forward)
-            assert isinstance(output, DiphoneLogitsV1) and not isinstance(output, DiphoneProbsV1)
-            assert output.output_left.shape == (b, t, n_ctx)
+            output_center, output_left, _ = block(features=encoder_output, contexts_left=contexts_forward)
+            assert output_left.shape == (b, t, n_ctx)
             cdim = get_center_dim(n_ctx, states_per_ph, we_class)
-            assert output.output_center.shape == (b, t, cdim)
+            assert output_center.shape == (b, t, cdim)
 
-        backend.train(False)
-        for b, t in product([10, 50, 100], [10, 50, 100]):
             encoder_output = torch.rand((b, t, n_in))
-            output = backend(features=encoder_output)
-            assert isinstance(output, DiphoneProbsV1)
-            assert output.output_left.shape == (b, t, n_ctx)
+            output = block.forward_joint(features=encoder_output)
             cdim = get_center_dim(n_ctx, states_per_ph, we_class)
-            assert output.output_center.shape == (b, t, cdim * n_ctx)
-            output_p = torch.exp(output.output_center)
+            assert output.shape == (b, t, cdim * n_ctx)
+            output_p = torch.exp(output)
             ones_hopefully = torch.sum(output_p, dim=-1)
             close_to_one = torch.abs(1 - ones_hopefully).flatten() < 1e-3
             assert all(close_to_one)


### PR DESCRIPTION
No triphone yet as there isn't an ONNX-compatible factored hybrid feature scorer yet and the diphone is compatible w/ `PrecomputedHybridFeatureScorer`. Support can be trivially amended though.