### PR TITLE
correct device for pos_emb

### DIFF
--- a/i6_models/parts/conformer/mhsa_rel_pos.py
+++ b/i6_models/parts/conformer/mhsa_rel_pos.py
@@ -252,7 +252,7 @@ class ConformerMHSARelPosV1(nn.Module):
 
         sinusoid_input = torch.outer(pos_seq, inv_freq)
 
-        pos_emb = torch.zeros(pos_seq.shape[0], embed_dim)
+        pos_emb = torch.zeros(pos_seq.shape[0], embed_dim, device=pos_seq.device)
 
         pos_emb[:, 0::2] = sinusoid_input.sin()
         pos_emb[:, 1::2] = sinusoid_input.cos()


### PR DESCRIPTION
Follow-up for #55 

When using the Transformer-XL style (`learnable_pos_emb=False`) the device for the sinusoidal embedding was not correctly set, causing a device mismatch when training on GPU. 

