### PR TITLE
Implement masked batch normalization

### DIFF
--- a/tests/test_masked_norm.py
+++ b/tests/test_masked_norm.py
@@ -1,0 +1,25 @@
+import torch
+
+from i6_models.parts.masked_norm import MaskedBatchNorm1dV1, _lengths_to_mask
+
+
+def test_masked_batch_norm():
+    data = torch.tensor(
+        [
+            list(range(10)),
+            list(range(10, 20)),
+        ]
+    ).unsqueeze(-1)
+    data_lens = torch.tensor([10, 5])
+    data_mask = _lengths_to_mask(data_lens)
+
+    norm = MaskedBatchNorm1dV1(num_features=1)
+    norm.train()
+    normed_data = norm(data, data_lens)
+    assert normed_data[data_mask].mean() < 1e-3
+    assert (normed_data[data_mask].var().sqrt() - 1) < 1e-1
+
+    norm = MaskedBatchNorm1dV1(num_features=1)
+    norm.train()
+    normed_data_via_mask: torch.Tensor = norm(data, data_mask)
+    assert torch.allclose(normed_data, normed_data_via_mask)


### PR DESCRIPTION
We commonly use the regular torch `nn.BatchNorm1d`, which does not mask non-sequence positions when computing the batch statistics. Masking them away is more correct.

Based on https://gist.github.com/amiasato/902fc14afa37a7537386f7b0c5537741.