### PR TITLE
Fbw 2 fsa builder

### DIFF
--- a/i6_models/parts/rasr_fsa.py
+++ b/i6_models/parts/rasr_fsa.py
@@ -200,7 +200,7 @@ class RasrFsaBuilderV2(RasrFsaBuilder):
     """
 
     def build_batch(self, seq_tags: Iterable[str]) -> WeightedFsaV2:
-        fsas = map(self.build_single, seq_tags)
+        fsas = list(map(self.build_single, seq_tags))
 
         num_states = [f[0] for f in fsas]
         num_edges = [f[1] for f in fsas]


### PR DESCRIPTION
To support a new version of fbw loss that accepts a different fsa interface from the previous fbw loss(with additional num_edges), we add a new RASR FSA builder.