### PR TITLE
Fix CI, fix ESPnet deps, older ctc-segmentation, pyworld

### DIFF
--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -21,6 +21,8 @@ jobs:
       - run: |
           pip install pytest
           pip install -r requirements.txt
+          # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
+          pip install ctc-segmentation==1.6.6 pyworld==0.3.4
           pip install -r requirements_dev.txt
       - name: Test Models
         run: |

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -21,6 +21,7 @@ jobs:
       - run: |
           pip install --upgrade pip setuptools wheel
           pip install pytest
+          # ESPnet needs Numpy 1.
           # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
           pip install numpy==1.23.5
           pip install ctc-segmentation==1.6.6 pyworld==0.3.4

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -22,7 +22,8 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
           # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
-          pip install numpy==1.23.5 ctc-segmentation==1.6.6 pyworld==0.3.4
+          pip install numpy==1.23.5
+          pip install ctc-segmentation==1.6.6 pyworld==0.3.4
           pip install -r requirements_dev.txt
       - name: Test Models
         run: |

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
           # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
-          pip install ctc-segmentation==1.6.6 pyworld==0.3.4 numpy==1.23.5
+          pip install numpy==1.23.5 ctc-segmentation==1.6.6 pyworld==0.3.4
           pip install -r requirements_dev.txt
       - name: Test Models
         run: |

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
           # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
-          pip install ctc-segmentation==1.6.6 pyworld==0.3.4
+          pip install ctc-segmentation==1.6.6 pyworld==0.3.4 numpy==1.23.5
           pip install -r requirements_dev.txt
       - name: Test Models
         run: |

--- a/.github/workflows/model_tests.yml
+++ b/.github/workflows/model_tests.yml
@@ -19,11 +19,12 @@ jobs:
           python-version: 3.8
           cache: 'pip'
       - run: |
+          pip install --upgrade pip setuptools wheel
           pip install pytest
-          pip install -r requirements.txt
           # Older Numpy 1 requires those older versions. (https://github.com/rwth-i6/i6_models/issues/78)
           pip install numpy==1.23.5
           pip install ctc-segmentation==1.6.6 pyworld==0.3.4
+          pip install -r requirements.txt
           pip install -r requirements_dev.txt
       - name: Test Models
         run: |


### PR DESCRIPTION
Fix #78.

Also see: https://github.com/rwth-i6/returnn/issues/1729
