### PR TITLE
RASR FSA join: add explicit dtypes for cumsum

### DIFF
--- a/i6_models/parts/rasr_fsa.py
+++ b/i6_models/parts/rasr_fsa.py
@@ -322,8 +322,8 @@ def join_fsas_fbw_v2(fsas: Iterable[FsaTuple]) -> WeightedFsaV2:
     fsas = list(fsas)  # ensure we can iterate multiple times over this iterable
     num_states = [f[0] for f in fsas]
     num_edges = [f[1] for f in fsas]
-    start_states = np.cumsum(np.array([0] + num_states, dtype=np.uint32))[:-1]
-    end_states = np.cumsum(num_states) - 1
+    start_states = np.cumsum(np.array([0] + num_states), dtype=np.uint32)[:-1]
+    end_states = np.cumsum(num_states, dtype=np.uint32) - 1
     weights = np.concatenate(tuple(f[3] for f in fsas))
 
     edges = []


### PR DESCRIPTION
If we use the default dtype, [np.cumsum](https://numpy.org/doc/stable/reference/generated/numpy.cumsum.html) fails when summing [here](https://github.com/rwth-i6/i6_models/blob/main/i6_models/parts/rasr_fsa.py#L332):

```
File "...work/i6_core/tools/git/CloneGitRepositoryJob.kJHGZFZS4N14/output/i6_models/i6_models/parts/rasr_fsa.py", line 332, in join_fsas_fbw_v2
    line: f_edges[:2, :] += start_states[idx]
    locals:
      f_edges = <local> array([[ 1,  2,  3,  0,  1,  2,  0,  2,  3,  1,  2,  0],
                               [ 1,  2,  3,  1,  2,  3,  2,  4,  4,  4,  4,  4],
                               [ 3, 14,  3,  3, 14,  3, 14, 14,  3, 14,  3, 14]], dtype=int32)
      start_states = <local> array([  0,   5,  10,  15,  20,  25,  30,  35,  40,  45,  50,  55,  60,
                                     65,  70,  75,  80,  85,  90,  97, 102, 107, 112, 117, 122, 127,
                                    132, 137, 142, 147, 152, 157, 162, 167, 172, 177, 182, 187, 192],
                                   dtype=uint64)
      idx = <local> 0
UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
```

This is because the cumsum dtype is actually `np.uint64`, and the first common parent of `np.int32` (allows negatives) and `np.uint64` (2x more range than `np.int64` in the positive side) is `np.float64`. Let me provide an example:

```
>>> start_states = np.cumsum(np.array([0] + [5, 5, 5], dtype=np.uint32))[:-1]                  
>>> start_states
array([ 0,  5, 10], dtype=uint64)
>>> f_edges = np.array([4, 4, 4, 4, 4, 4, 4, 4, 4], dtype=np.int32).reshape(3, -1).copy()
>>> np.result_type(start_states, f_edges[:2, :])
dtype('float64')
>>> f_edges[:2, :] += start_states              
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
```

This PR fixes such an issue with the default cumsum by explicitly setting `np.uint32` as default dtype for the cumsum operation.